### PR TITLE
Add message for `assert.equal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ We are currently supporting the following assertions
 
 * `ok`
 * `notOk`
+* `equal`
 
 But plan to keep adding more.
 

--- a/lib/transform-qunit-assertions.js
+++ b/lib/transform-qunit-assertions.js
@@ -19,6 +19,15 @@ function transformUnaryAssertion(node, prefix) {
   }
 }
 
+function transformBinaryAssertion(node, prefix) {
+  if (node.arguments.length === 2) {
+    var arg1 = node.arguments[0];
+    var arg2 = node.arguments[1];
+    var str = recast.print(arg1).code + ' ' + recast.print(arg2).code;
+    node.arguments.push(builders.literal(prefix + str));
+  }
+}
+
 function isTestCall(node) {
   return types.Identifier.check(node.callee) &&
     node.callee.name === 'test';
@@ -46,6 +55,8 @@ module.exports = function transform(source) {
         transformUnaryAssertion(node, 'ok: ');
       } else if(isAssertion(node, assert, 'notOk')) {
         transformUnaryAssertion(node, 'not ok: ');
+      } else if(isAssertion(node, assert, 'equal')){
+        transformBinaryAssertion(node, 'equal: ');
       }
 
       this.traverse(path);

--- a/lib/transform-qunit-assertions.js
+++ b/lib/transform-qunit-assertions.js
@@ -23,7 +23,7 @@ function transformBinaryAssertion(node, prefix) {
   if (node.arguments.length === 2) {
     var arg1 = node.arguments[0];
     var arg2 = node.arguments[1];
-    var str = recast.print(arg1).code + ' ' + recast.print(arg2).code;
+    var str = recast.print(arg1).code + ' == ' + recast.print(arg2).code;
     node.arguments.push(builders.literal(prefix + str));
   }
 }

--- a/node-tests/fixtures/original/equal.js
+++ b/node-tests/fixtures/original/equal.js
@@ -1,0 +1,27 @@
+import { testHelper } from 'shell/helpers/test-helper';
+import { module, test } from 'qunit';
+
+function testFunction(a) {
+  return a;
+}
+
+module('Unit | Helper | test helper');
+
+//Replace this with your real tests.
+test('it works', function(assert) {
+  let result = testHelper([42]),
+      obj = { a: true, b: false };
+
+  assert.equal(result, true);
+  assert.equal((function() { return true; })(), (function() { return true; })());
+  assert.equal(1, 1, 'testing equality');
+  assert.equal(true, true);
+  assert.equal((1+2+3)-3*5*6, -84);
+  assert.equal(function() { return true; }(), function(){ return true; }(), 'testing a function');
+  assert.equal(obj.a, obj.b);
+  assert.equal(testFunction(true), testFunction(true));
+});
+
+test('it works - variable', function(a) {
+  a.equal(result, result);
+});

--- a/node-tests/fixtures/transformed/equal.js
+++ b/node-tests/fixtures/transformed/equal.js
@@ -12,16 +12,16 @@ test('it works', function(assert) {
   let result = testHelper([42]),
       obj = { a: true, b: false };
 
-  assert.equal(result, true, 'equal: result true');
-  assert.equal((function() { return true; })(), (function() { return true; })(),'equal: (function() { return true; })() (function() { return true; })()');
+  assert.equal(result, true, 'equal: result == true');
+  assert.equal((function() { return true; })(), (function() { return true; })(),'equal: (function() { return true; })() == (function() { return true; })()');
   assert.equal(1, 1, 'testing equality');
-  assert.equal(true, true, 'equal: true true');
-  assert.equal((1+2+3)-3*5*6, -84, 'equal: (1+2+3)-3*5*6 -84');
+  assert.equal(true, true, 'equal: true == true');
+  assert.equal((1+2+3)-3*5*6, -84, 'equal: (1+2+3)-3*5*6 == -84');
   assert.equal(function() { return true; }(), function(){ return true; }(), 'testing a function');
-  assert.equal(obj.a, obj.b, 'equal: obj.a obj.b');
-  assert.equal(testFunction(true), testFunction(true), 'equal: testFunction(true) testFunction(true)');
+  assert.equal(obj.a, obj.b, 'equal: obj.a == obj.b');
+  assert.equal(testFunction(true), testFunction(true), 'equal: testFunction(true) == testFunction(true)');
 });
 
 test('it works - variable', function(a) {
-  a.equal(result, result, 'equal: result result');
+  a.equal(result, result, 'equal: result == result');
 });

--- a/node-tests/fixtures/transformed/equal.js
+++ b/node-tests/fixtures/transformed/equal.js
@@ -1,0 +1,27 @@
+import { testHelper } from 'shell/helpers/test-helper';
+import { module, test } from 'qunit';
+
+function testFunction(a) {
+  return a;
+}
+
+module('Unit | Helper | test helper');
+
+//Replace this with your real tests.
+test('it works', function(assert) {
+  let result = testHelper([42]),
+      obj = { a: true, b: false };
+
+  assert.equal(result, true, 'equal: result true');
+  assert.equal((function() { return true; })(), (function() { return true; })(),'equal: (function() { return true; })() (function() { return true; })()');
+  assert.equal(1, 1, 'testing equality');
+  assert.equal(true, true, 'equal: true true');
+  assert.equal((1+2+3)-3*5*6, -84, 'equal: (1+2+3)-3*5*6 -84');
+  assert.equal(function() { return true; }(), function(){ return true; }(), 'testing a function');
+  assert.equal(obj.a, obj.b, 'equal: obj.a obj.b');
+  assert.equal(testFunction(true), testFunction(true), 'equal: testFunction(true) testFunction(true)');
+});
+
+test('it works - variable', function(a) {
+  a.equal(result, result, 'equal: result result');
+});

--- a/node-tests/transform-qunit-assertions-test.js
+++ b/node-tests/transform-qunit-assertions-test.js
@@ -19,4 +19,8 @@ describe('transform qunit assertions', function() {
   it('transforms: adds message to notOk assertion without message', function() {
     assertOutput('not-ok');
   });
+
+  it('transforms: adds message to equal assertion without message', function() {
+    assertOutput('equal');
+  });
 });

--- a/node-tests/transform-qunit-assertions-test.js
+++ b/node-tests/transform-qunit-assertions-test.js
@@ -3,12 +3,23 @@
 var transform = require('../lib/transform-qunit-assertions');
 var assert = require('chai').assert;
 var fs = require('fs');
+var recast = require('recast');
+
+function prettify(source) {
+  var ast = recast.parse(source);
+  return recast.prettyPrint(ast).code;
+}
 
 function assertOutput(fileName) {
   var source = fs.readFileSync('./node-tests/fixtures/original/' + fileName + '.js', 'utf8');
   var transformed = fs.readFileSync('./node-tests/fixtures/transformed/' + fileName + '.js', 'utf8');
 
-  assert.equal(transform(source), transformed);
+  var transformedSource = transform(source);
+
+  var prettyTransformedSource = prettify(transformedSource);
+  var prettyTransformedExpected = prettify(transformed);
+
+  assert.equal(prettyTransformedExpected, prettyTransformedSource);
 }
 
 describe('transform qunit assertions', function() {


### PR DESCRIPTION
Issue #9 is added in the first commit.

Until now the test where format dependant because the only thing guaranteed by`recast` about formatting is `recast.print(recast.parse(source)).code === source`. Because of that the tests where too fragile. Now the test should be independent of the file formatting.
