### PR TITLE
Validate ember build works as expected

### DIFF
--- a/node-tests/acceptance-test.js
+++ b/node-tests/acceptance-test.js
@@ -1,0 +1,25 @@
+var assert = require('chai').assert;
+var exec = require('child_process').exec;
+var fs = require('fs');
+
+describe('Acceptance', function() {
+  it('transforms assertions on build', function(done) {
+    this.timeout(300000);
+
+    exec('ember build', function(_, stdout) {
+      assert.include(stdout, 'Built project successfully. Stored in "dist/".');
+
+      fs.readFile('./dist/assets/tests.js', 'utf8', function(err, data) {
+        if (err) {
+          throw err;
+        }
+
+        assert.include(data, "assert.ok(fooTruthy, 'assert.ok(fooTruthy)');");
+        assert.include(data, "assert.notOk(!fooTruthy, 'assert.notOk(!fooTruthy)');");
+        assert.include(data, "assert.equal(5 * 2, 2 * 5, 'assert.equal(5*2, 2*5)');");
+
+        done();
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "ember build",
-    "test": "ember try:testall && mocha node-tests/*-test.js",
+    "test": "ember try:testall && npm run node-test",
     "ember-test": "ember try:testall",
     "node-test": "mocha node-tests/*-test.js"
   },

--- a/tests/unit/example-test.js
+++ b/tests/unit/example-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+
+module('Unit | example');
+
+test('passes all assertions', function(assert) {
+  var fooTruthy = true;
+
+  assert.ok(fooTruthy);
+  assert.notOk(!fooTruthy);
+  assert.equal(5*2, 2*5);
+});


### PR DESCRIPTION
I've added an acceptance test to validate two different things:
* The addon doesn't break the build (we could add more assert types to `tests/unit/example-test.js` to increase coverage)
* The generated tests.js is transformed as expected, this means that the build filters are all in place