### PR TITLE
Add override option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ if (environment === 'development') {
 }
 ```
 
+### completionMode
+
+If you fully trust us you can add this option to replace all assertions within your project tests, just add this to your configuration on your `config/environment.js` file:
+
+```js
+ENV['ember-qunit-nice-errors'] = {
+  completionMode: 'override'
+};
+```
+
+Don't worry, the override will still show your orginal messages, it is not a destructive operation!
+
 ## Supported assertions
 
 We are currently supporting all the assertions provided by QUnit, those are:

--- a/README.md
+++ b/README.md
@@ -53,17 +53,18 @@ if (environment === 'development') {
 }
 ```
 
-### completionMode
+### completeExistingMessages
 
 If you fully trust us you can add this option to replace all assertions within your project tests, just add this to your configuration on your `config/environment.js` file:
 
 ```js
 ENV['ember-qunit-nice-errors'] = {
-  completionMode: 'override'
+  completeExistingMessages: true
 };
 ```
 
 Don't worry, the override will still show your orginal messages, it is not a destructive operation!
+The messages that you already have will go from `assert.ok(1 === 1, 'one should be one')` to `assert.ok(1 === 1, "assert.ok(1 === 1, 'one should be one')")`.
 
 ## Supported assertions
 

--- a/lib/tests-transform-filter.js
+++ b/lib/tests-transform-filter.js
@@ -21,8 +21,8 @@ TestTransformFilter.prototype.processString = function(content, relativePath) {
     transformOpts['file'] = relativePath;
   }
 
-  if (this.options.completionMode) {
-    transformOpts['completionMode'] = this.options.completionMode;
+  if (this.options.completeExistingMessages) {
+    transformOpts['completeExistingMessages'] = this.options.completeExistingMessages;
   }
 
   return transform(content, transformOpts);

--- a/lib/tests-transform-filter.js
+++ b/lib/tests-transform-filter.js
@@ -15,7 +15,15 @@ TestTransformFilter.prototype.canProcessFile = function(relativePath) {
   return /-test\.js/.test(relativePath);
 };
 TestTransformFilter.prototype.processString = function(content, relativePath) {
-  var transformOpts = this.options.showFileInfo ? { file: relativePath } : {};
+  var transformOpts = {};
+
+  if (this.options.showFileInfo) {
+    transformOpts['file'] = relativePath;
+  }
+
+  if (this.options.completionMode) {
+    transformOpts['completionMode'] = this.options.completionMode;
+  }
 
   return transform(content, transformOpts);
 };

--- a/lib/transform-qunit-assertions.js
+++ b/lib/transform-qunit-assertions.js
@@ -45,21 +45,17 @@ function addAssertionMessage(node, message) {
 }
 
 function replaceAssertionMessage(node, message) {
-  if (needsMessage(node)) {
-    addAssertionMessage(node, message);
-  } else {
-    node.arguments.pop();
-    node.arguments.push(builders.literal(message));
-  }
+  node.arguments.pop();
+  addAssertionMessage(node, message);
 }
 
 function processAssertion(node, options) {
   var message = buildMessage(node, options);
 
-  if (options && options.completionMode === 'override') {
-    replaceAssertionMessage(node, message);
-  } else if (needsMessage(node)){
+  if (needsMessage(node)) {
     addAssertionMessage(node, message);
+  } else if (options && options.completeExistingMessages) {
+    replaceAssertionMessage(node, message);
   }
 }
 

--- a/lib/transform-qunit-assertions.js
+++ b/lib/transform-qunit-assertions.js
@@ -53,22 +53,11 @@ function replaceAssertionMessage(node, message) {
   }
 }
 
-function appendAssertionMessage(node, message) {
-  if (needsMessage(node)) {
-    addAssertionMessage(node, message);
-  } else {
-    var newMessage = node.arguments.pop().value + ' - ' + message;
-    node.arguments.push(builders.literal(newMessage));
-  }
-}
-
 function processAssertion(node, options) {
   var message = buildMessage(node, options);
 
   if (options && options.completionMode === 'override') {
     replaceAssertionMessage(node, message);
-  } else if (options && options.completionMode === 'append'){
-    appendAssertionMessage(node, message);
   } else if (needsMessage(node)){
     addAssertionMessage(node, message);
   }

--- a/lib/transform-qunit-assertions.js
+++ b/lib/transform-qunit-assertions.js
@@ -30,14 +30,48 @@ function isAssertionOfType(node, types) {
   return types.indexOf(node.callee.property.name) !== -1;
 }
 
-function addAssertionMessage(node, options) {
+function buildMessage(node, options) {
   var str = recast.print(node).code;
 
   if (options && options.file) {
     str += ' at ' + location(node, options.file);
   }
 
-  node.arguments.push(builders.literal(str));
+  return str;
+}
+
+function addAssertionMessage(node, message) {
+  node.arguments.push(builders.literal(message));
+}
+
+function replaceAssertionMessage(node, message) {
+  if (needsMessage(node)) {
+    addAssertionMessage(node, message);
+  } else {
+    node.arguments.pop();
+    node.arguments.push(builders.literal(message));
+  }
+}
+
+function appendAssertionMessage(node, message) {
+  if (needsMessage(node)) {
+    addAssertionMessage(node, message);
+  } else {
+    var newMessage = node.arguments.pop().value + ' - ' + message;
+    node.arguments.push(builders.literal(newMessage));
+  }
+}
+
+function processAssertion(node, options) {
+  var message = buildMessage(node, options);
+
+  if (options && options.completionMode === 'override') {
+    replaceAssertionMessage(node, message);
+  } else if (options && options.completionMode === 'append'){
+    appendAssertionMessage(node, message);
+  } else if (needsMessage(node)){
+    addAssertionMessage(node, message);
+  }
 }
 
 function location(node, filePath) {
@@ -67,8 +101,8 @@ module.exports = function transform(source, options) {
 
       if (isTestCall(node)) {
         assert = assertName(node);
-      } else if (isAssertion(node, assert) && needsMessage(node)) {
-        addAssertionMessage(node, options);
+      } else if (isAssertion(node, assert)) {
+        processAssertion(node, options);
       }
 
       this.traverse(path);

--- a/node-tests/fixtures/original/integration/completion-mode/example-test.js
+++ b/node-tests/fixtures/original/integration/completion-mode/example-test.js
@@ -1,0 +1,10 @@
+import { testHelper } from 'shell/helpers/test-helper';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | test helper');
+
+test('it works', function(assert) {
+  assert.ok(result);
+  assert.notOk(1===1, '1 should not be equal to 1');
+  assert.equal(1, 2, '1 should be equal 2');
+});

--- a/node-tests/fixtures/original/integration/completion-with-file/example-test.js
+++ b/node-tests/fixtures/original/integration/completion-with-file/example-test.js
@@ -1,0 +1,10 @@
+import { testHelper } from 'shell/helpers/test-helper';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | test helper');
+
+test('it works', function(assert) {
+  assert.ok(result);
+  assert.notOk(1===1, 'one should not be equal to one');
+     assert.equal(1, 2, '1 should be equal to two');
+});

--- a/node-tests/fixtures/transformed/integration/completion-mode/example-test.js
+++ b/node-tests/fixtures/transformed/integration/completion-mode/example-test.js
@@ -1,0 +1,10 @@
+import { testHelper } from 'shell/helpers/test-helper';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | test helper');
+
+test('it works', function(assert) {
+  assert.ok(result, 'assert.ok(result)');
+  assert.notOk(1===1, "assert.notOk(1===1, '1 should not be equal to 1')");
+  assert.equal(1, 2, "assert.equal(1, 2, '1 should be equal 2')");
+});

--- a/node-tests/fixtures/transformed/integration/completion-with-file/example-test.js
+++ b/node-tests/fixtures/transformed/integration/completion-with-file/example-test.js
@@ -1,0 +1,10 @@
+import { testHelper } from 'shell/helpers/test-helper';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | test helper');
+
+test('it works', function(assert) {
+  assert.ok(result, 'assert.ok(result) at example-test.js:7:2');
+  assert.notOk(1===1, "assert.notOk(1===1, 'one should not be equal to one') at example-test.js:8:2");
+     assert.equal(1, 2, "assert.equal(1, 2, '1 should be equal to two') at example-test.js:9:5");
+});

--- a/node-tests/tests-transform-filter-test.js
+++ b/node-tests/tests-transform-filter-test.js
@@ -37,14 +37,14 @@ describe('transform test files on build', function() {
     });
   });
 
-  it('transforms assertions with override completion mode', function() {
-    return build('fixtures/original/integration/completion-mode', { completionMode: 'override' }).then(function(results) {
+  it('transforms assertions with complete existing messages option', function() {
+    return build('fixtures/original/integration/completion-mode', { completeExistingMessages: true }).then(function(results) {
       assertBuild(results, 'fixtures/transformed/integration/completion-mode');
     });
   });
 
-  it('transforms assertions with override completion mode and adds file and line number', function() {
-    return build('fixtures/original/integration/completion-with-file', { showFileInfo: true, completionMode: 'override' }).then(function(results) {
+  it('transforms assertions with complete existing messages and adds file and line number', function() {
+    return build('fixtures/original/integration/completion-with-file', { showFileInfo: true, completeExistingMessages: true }).then(function(results) {
       assertBuild(results, 'fixtures/transformed/integration/completion-with-file');
     });
   });

--- a/node-tests/tests-transform-filter-test.js
+++ b/node-tests/tests-transform-filter-test.js
@@ -36,6 +36,18 @@ describe('transform test files on build', function() {
       assertBuild(results, 'fixtures/transformed/integration/with-file');
     });
   });
+
+  it('transforms assertions with override completion mode', function() {
+    return build('fixtures/original/integration/completion-mode', { completionMode: 'override' }).then(function(results) {
+      assertBuild(results, 'fixtures/transformed/integration/completion-mode');
+    });
+  });
+
+  it('transforms assertions with override completion mode and adds file and line number', function() {
+    return build('fixtures/original/integration/completion-with-file', { showFileInfo: true, completionMode: 'override' }).then(function(results) {
+      assertBuild(results, 'fixtures/transformed/integration/completion-with-file');
+    });
+  });
 });
 
 function assertBuild(results, transformedFolder) {


### PR DESCRIPTION
This adds an option to override the already existing assertions (#13). The override it is not a destructive override because it adds the original message to the new one, it works like this:

`assert.ok(1 === 1, 'one should be one')` ===> `assert.ok(1 === 1, "assert.ok(1 === 1, 'one should be one')")`

The assertions that don't have something set by you will be replaced with the default message just like it is right now.

The option is available via the app configuration: 

```js
ENV['ember-qunit-nice-errors'] = {
  completionMode: 'override'
};