### PR TITLE
Ignore files that recast fails to parse

### DIFF
--- a/lib/transform-qunit-assertions.js
+++ b/lib/transform-qunit-assertions.js
@@ -74,22 +74,26 @@ function assertName(node) {
 }
 
 module.exports = function transform(source, options) {
-  var ast = recast.parse(source);
-  var assert = 'assert';
+  try {
+    var ast = recast.parse(source);
+    var assert = 'assert';
 
-  recast.visit(ast, {
-    visitCallExpression: function(path){
-      var node = path.node;
+    recast.visit(ast, {
+      visitCallExpression: function(path){
+        var node = path.node;
 
-      if (isTestCall(node)) {
-        assert = assertName(node);
-      } else if (isSupportedAssertion(node, assert)) {
-        processAssertion(node, options);
+        if (isTestCall(node)) {
+          assert = assertName(node);
+        } else if (isSupportedAssertion(node, assert)) {
+          processAssertion(node, options);
+        }
+
+        this.traverse(path);
       }
+    });
 
-      this.traverse(path);
-    }
-  });
-
-  return recast.print(ast, {quote: 'single'}).code;
+    return recast.print(ast, {quote: 'single'}).code;
+  } catch (err) {
+    return source;
+  }
 };

--- a/node-tests/fixtures/original/integration/unsupported-file/async-await-test.js
+++ b/node-tests/fixtures/original/integration/unsupported-file/async-await-test.js
@@ -1,0 +1,9 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | index');
+
+test('scott visiting /index', async assert {
+  await visit('/');
+  assert.equal(currentURL(), '/');
+});

--- a/node-tests/fixtures/original/integration/unsupported-file/syntax-error-test.js
+++ b/node-tests/fixtures/original/integration/unsupported-file/syntax-error-test.js
@@ -1,0 +1,8 @@
+import { module, test } from 'qunit';
+
+module('Unit | Helper | test');
+
+test('it works', function(assert) {
+  assert.ok(false);
+  assert.equal({}, {);
+});

--- a/node-tests/tests-transform-filter-test.js
+++ b/node-tests/tests-transform-filter-test.js
@@ -48,16 +48,26 @@ describe('transform test files on build', function() {
       assertBuild(results, 'fixtures/transformed/integration/completion-with-file');
     });
   });
+
+  it('ignores files with unsopported features or parse errors', function() {
+    return build('fixtures/original/integration/unsupported-file').then(function(results) {
+      assertBuild(results, 'fixtures/original/integration/unsupported-file', true);
+    });
+  });
 });
 
-function assertBuild(results, transformedFolder) {
+function assertBuild(results, transformedFolder, exactMatch) {
   var original, transformed;
 
   files(results).forEach(function(file) {
     original = fs.readFileSync(path.join(results.directory, file), 'utf8');
     transformed = fs.readFileSync(path.join(__dirname, transformedFolder, file), 'utf8');
 
-    assert.equal(prettify(original), prettify(transformed));
+    if (exactMatch) {
+      assert.equal(original, transformed);
+    } else {
+      assert.equal(prettify(original), prettify(transformed));
+    }
   });
 }
 


### PR DESCRIPTION
Suggested by https://github.com/wyeworks/ember-qunit-nice-errors/issues/35, small fix so at least the build doesn't break as reported in https://github.com/wyeworks/ember-qunit-nice-errors/issues/18