### PR TITLE
update recast version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "babel-core": "^6.10.4",
     "broccoli-filter": "^1.2.4",
     "ember-cli-babel": "^6.3.0",
-    "recast": "^0.11.22"
+    "recast": "^0.13.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
This PR updates the `recast` version to the latest in order to update the underlying `esprima` dependency.

This update allows the usage of ECMAScript 2017 features such as async/await.

It fix #51 

