### PR TITLE
Replace broccoli-filter with broccoli-persistent-filter

### DIFF
--- a/lib/tests-transform-filter.js
+++ b/lib/tests-transform-filter.js
@@ -1,11 +1,12 @@
 /*eslint-env node*/
 'use strict';
 
-var Filter = require('broccoli-filter');
+var Filter = require('broccoli-persistent-filter');
 var transform = require('./transform-qunit-assertions');
+var path = require('path');
 
 function TestTransformFilter(inputNode, options) {
-  this.options = options;
+  this.options = Object.assign({ persist: true }, options);
   Filter.call(this, inputNode, this.options);
 }
 
@@ -14,6 +15,11 @@ TestTransformFilter.prototype.constructor = TestTransformFilter;
 TestTransformFilter.prototype.canProcessFile = function(relativePath) {
   return /-test\.js/.test(relativePath);
 };
+
+TestTransformFilter.prototype.baseDir = function() {
+  return path.resolve(__dirname, '..');
+}
+
 TestTransformFilter.prototype.processString = function(content, relativePath) {
   var transformOpts = {};
 
@@ -26,6 +32,20 @@ TestTransformFilter.prototype.processString = function(content, relativePath) {
   }
 
   return transform(content, transformOpts);
+};
+
+TestTransformFilter.prototype.optionsHash = function() {
+  if (!this._optionsHash) {
+    this._optionsHash = JSON.stringify(this.options);
+  }
+
+  return this._optionsHash;
+};
+
+TestTransformFilter.prototype.cacheKeyProcessString = function(string, relativePath) {
+  return Filter.prototype.cacheKeyProcessString.call(
+    this, string + this.optionsHash(), relativePath
+  );
 };
 
 module.exports = TestTransformFilter;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-core": "^6.10.4",
-    "broccoli-filter": "^1.2.4",
+    "broccoli-persistent-filter": "^1.4.3",
     "ember-cli-babel": "^6.3.0",
     "recast": "^0.13.0"
   },


### PR DESCRIPTION
I know you have a WIP PR in https://github.com/wyeworks/ember-qunit-nice-errors/pull/55 but I have a working PR with broccoli-persistent-filter which we are using in our app. It gives us substantial performance gains, reducing warm build times by ~15 seconds over current `master` (we have a lot of tests!).